### PR TITLE
Add ability to develop new features quickly via an external file

### DIFF
--- a/detprocess/process/_process.py
+++ b/detprocess/process/_process.py
@@ -3,6 +3,9 @@ import warnings
 from pathlib import Path
 import numpy as np
 import pandas as pd
+import importlib
+import sys
+
 
 from detprocess.io._load import load_traces
 from detprocess.io._save import save_features
@@ -12,6 +15,24 @@ from detprocess.process._features import repack_h5info_dict, SingleChannelExtrac
 __all__ = [
     'process_data',
 ]
+
+
+
+def _load_module(file_path):
+    """
+    Helper function for loading an alternative SingleChannelExtractors
+    class.
+
+    """
+    
+    module_name = 'detprocess.process'
+
+    spec = importlib.util.spec_from_file_location(module_name, file_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+    return module.SingleChannelExtractors
 
 
 def _get_single_channel_feature_names(chan_dict):
@@ -25,7 +46,8 @@ def _get_single_channel_feature_names(chan_dict):
     return feature_list
 
 
-def process_data(raw_file, path_to_yaml, savepath, nevents=0):
+def process_data(raw_file, path_to_yaml, savepath, nevents=0,
+                 external_file=None):
     """
     Function for extracting features from a data file using the
     settings from a specified YAML file.
@@ -45,11 +67,17 @@ def process_data(raw_file, path_to_yaml, savepath, nevents=0):
     nevents : int, optional
         The number of events to process in the file. Default of 0 is to
         process all events. Generally used for development purposes.
+    external_file : str, NonesType, optional
+        The path to a .py file with an alternative
+        SingleChannelExtractors class to be used instead of the default
+        in detprocess, meant for rapid development of features without
+        needing to rebuild the package.
 
     Returns
     -------
     feature_df : Pandas.DataFrame
-        A DataFrame containing all of the extracted features for the given file.
+        A DataFrame containing all of the extracted features for the
+        given file.
 
     """
 
@@ -58,6 +86,11 @@ def process_data(raw_file, path_to_yaml, savepath, nevents=0):
             'savepath has been set to None, the extracted features '
             'will be returned, but not saved to a file.'
         )
+
+    if external_file is not None:
+        SCE = _load_module(external_file)
+    else:
+        SCE = SingleChannelExtractors
 
     with open(path_to_yaml) as f:
         yaml_dict = yaml.safe_load(f)
@@ -81,7 +114,7 @@ def process_data(raw_file, path_to_yaml, savepath, nevents=0):
                 kwargs['template'] = template
                 kwargs['psd'] = psd
                 kwargs['fs'] = fs
-                extractor = getattr(SingleChannelExtractors, feature)
+                extractor = getattr(SCE, feature)
                 extracted_dict = extractor(trace, **kwargs)
                 for ex_feature in extracted_dict:
                     ex_feature_name = f'{ex_feature}_{chan}'

--- a/examples/run_detprocess.ipynb
+++ b/examples/run_detprocess.ipynb
@@ -58,6 +58,7 @@
     "        yaml_path,\n",
     "        save_path, # pass None if you don't want to save the file (for debugging)\n",
     "#         nevents=10, # process only the first 10 events (for debugging)\n",
+    "#         external_file=None, # set to the path to an external file that contains different features than the default (see the README for more info)\n",
     "    )"
    ]
   },


### PR DESCRIPTION
This PR allows the user to pass a path to an alternative version of `detprocess/process/_features.py` for fast development of new or one-off features. The change is that the `external_file` keyword argument was added to `detprocess.process_data`, to which a path to a file which contains the Python code for features to extract. With this update, the code loads the `SingleChannelExtractors` class from that file instead of the default version, and uses the functions therein for feature extraction. This allows the user to create new features on the fly without needing to rebuild the package each time.

The documentation has also been updated to discuss how to use this optional keyword argument in `detprocess.process_data` when an external file is desired.