### PR TITLE
fixed bug for high sigma triggers, assumes k=1 in chi2 distribution

### DIFF
--- a/detprocess/core/oftrigger.py
+++ b/detprocess/core/oftrigger.py
@@ -907,8 +907,17 @@ class OptimumFilterTrigger:
         # This is done so that the trigger behaves roughly as it used to,
         # while accounting for the difference between a chi2 and Gaussian
         # distribution.
-        survival_fraction = stats.norm.sf(thresh) * 2
-        chi2_threshold = special.gammainccinv(self._m_amplitudes / 2, survival_fraction) * 2
+        
+        #stats.norm.sf can't give arbitrarilly small values, need to switch
+        #to a different calculation method around threshold = 30. We'll just
+        #assume k = 1 so chi^2 = sigma^2
+        
+        if thresh < 25:
+            survival_fraction = stats.norm.sf(thresh) * 2
+            chi2_threshold = special.gammainccinv(self._m_amplitudes / 2, survival_fraction) * 2
+        else: 
+            chi2_threshold = thresh**2
+        
         triggers_mask = self._delta_chi2_trace > chi2_threshold
 
         triggers = np.where(triggers_mask)[0]

--- a/detprocess/process/features.py
+++ b/detprocess/process/features.py
@@ -500,7 +500,7 @@ class FeatureProcessing:
                         speed = event_counter/time_running
                         print('INFO' + node_num_str
                               + ': Speed = '
-                              + str(speed) + ' events per second')
+                              + f'{speed:.4e}' + ' events per second')
                         
                 # -----------------------
                 # Read next event

--- a/detprocess/process/features.py
+++ b/detprocess/process/features.py
@@ -473,6 +473,7 @@ class FeatureProcessing:
 
             # loop events
             do_stop = False
+            start_time = time.time()
             while (not do_stop):
 
                 # -----------------------
@@ -493,6 +494,13 @@ class FeatureProcessing:
                               + ': Local number of events = '
                               + str(event_counter)
                               + ' (memory = ' + str(memory_usage/1e6) + ' MB)')
+                              
+                    if (event_counter%1000==0 and event_counter!=0):
+                        time_running = time.time() - start_time
+                        speed = event_counter/time_running
+                        print('INFO' + node_num_str
+                              + ': Speed = '
+                              + str(speed) + ' events per second')
                         
                 # -----------------------
                 # Read next event


### PR DESCRIPTION
There was an unexpected bug in vetri's new delta chi2 based triggering for very high sigma thresholds, I've done a somewhat kludgy fix which assumes the chi2 distribution at high thresholds is consistent with a k = 1 distribution, i.e. chi2 = sigma^2