### PR TITLE
Implement the residual trigger into the full detprocess chain

### DIFF
--- a/detprocess/core/eventbuilder.py
+++ b/detprocess/core/eventbuilder.py
@@ -126,7 +126,8 @@ class EventBuilder:
     def acquire_triggers(self, trigger_name, trace, thresh,
                          pileup_window_msec=None,
                          pileup_window_samples=None,
-                         positive_pulses=True):
+                         positive_pulses=True,
+                         run_residual=False):
         """
         calc
         """
@@ -148,7 +149,9 @@ class EventBuilder:
             thresh,
             pileup_window_msec=pileup_window_msec,
             pileup_window_samples=pileup_window_samples,
-            positive_pulses=positive_pulses)
+            positive_pulses=positive_pulses,
+            residual=run_residual
+        )
 
         # append trigger data to event dataframe
         # sort by trigger index

--- a/detprocess/core/eventbuilder.py
+++ b/detprocess/core/eventbuilder.py
@@ -127,7 +127,8 @@ class EventBuilder:
                          pileup_window_msec=None,
                          pileup_window_samples=None,
                          positive_pulses=True,
-                         run_residual=False):
+                         run_residual=False,
+                         sat_amps_50kHz=None):
         """
         calc
         """
@@ -150,7 +151,8 @@ class EventBuilder:
             pileup_window_msec=pileup_window_msec,
             pileup_window_samples=pileup_window_samples,
             positive_pulses=positive_pulses,
-            residual=run_residual
+            residual=run_residual,
+            saturation_amplitudes_LPF_50kHz=sat_amps_50kHz
         )
 
         # append trigger data to event dataframe

--- a/detprocess/core/oftrigger.py
+++ b/detprocess/core/oftrigger.py
@@ -204,7 +204,7 @@ def shift_templates_to_match_chi2(fs, primary_template, secondary_templates, noi
         elif n_dims_template == 2:
             if secondary_template.shape[0] == 1:
                 s_template = np.reshape(secondary_template, (1, 1, secondary_template.shape[1]))
-            elif template.shape[1] == 1:
+            elif secondary_template.shape[1] == 1:
                 s_template = np.reshape(secondary_template, (1, 1, secondary_template.shape[0]))
             else:
                 raise ValueError(
@@ -796,6 +796,7 @@ class OptimumFilterTrigger:
             # Return self._delta_chi2_trace to its original value
             # because right now, it is saving the residual trace.
             self._residual_delta_chi2_trace = np.copy(self._delta_chi2_trace)
+            new_delta_chi2_trace = np.copy(self._delta_chi2_trace)
             self._delta_chi2_trace = np.copy(original_delta_chi2_trace)
             
             # Combine all triggers into a single dictionary

--- a/detprocess/process/triggers.py
+++ b/detprocess/process/triggers.py
@@ -23,7 +23,7 @@ from detprocess.core.eventbuilder import EventBuilder
 from detprocess.core.oftrigger import OptimumFilterTrigger
 from detprocess.utils import utils
 from detprocess.core.rawdata import RawData
-
+from distutils.util import strtobool
 import pyarrow as pa
 warnings.filterwarnings('ignore')
 
@@ -724,6 +724,12 @@ class TriggerProcessing:
                         pileup_window_samples = int(
                             trig_data['pileup_window_samples'])
 
+                    # residual triggering
+                    run_residual = False
+                    if 'run_residual' in trig_data.keys():
+                        run_residual = bool(
+                            trig_data['run_residual'])
+
                     # positive pulse
                     positive_pulses = True
                     if 'positive_pulses' in trig_data.keys():
@@ -741,7 +747,9 @@ class TriggerProcessing:
                         threshold,
                         pileup_window_msec=pileup_window_msec,
                         pileup_window_samples=pileup_window_samples,
-                        positive_pulses=positive_pulses)
+                        positive_pulses=positive_pulses,
+                        run_residual=run_residual
+                        )
 
 
                 # -----------------------

--- a/detprocess/process/triggers.py
+++ b/detprocess/process/triggers.py
@@ -726,9 +726,13 @@ class TriggerProcessing:
 
                     # residual triggering
                     run_residual = False
+                    sat_amps_50kHz = None
                     if 'run_residual' in trig_data.keys():
                         run_residual = bool(
                             trig_data['run_residual'])
+                        if 'sat_amps_50kHz' in trig_data.keys():
+                            sat_amps_50kHz = trig_data['sat_amps_50kHz']
+                            sat_amps_50kHz = [float(amp) for amp in sat_amps_50kHz]
 
                     # positive pulse
                     positive_pulses = True
@@ -748,7 +752,8 @@ class TriggerProcessing:
                         pileup_window_msec=pileup_window_msec,
                         pileup_window_samples=pileup_window_samples,
                         positive_pulses=positive_pulses,
-                        run_residual=run_residual
+                        run_residual=run_residual,
+                        sat_amps_50kHz=sat_amps_50kHz
                         )
 
 

--- a/examples/processing/process_example.yaml
+++ b/examples/processing/process_example.yaml
@@ -63,12 +63,19 @@ trigger:
 
         trigger_channel: Melange025pc
 
-        of2x2_shared:
+        of2x1_shared:
             run: True
             template_tag: shared
             csd_tag: default
             pileup_window_msec: 2
             threshold_sigma: 4.0
+            run_residual: True
+            sat_amps_50kHz: [inf]
+               # Saturation amplitude in amps, after applying a 50 kHz LPF.
+               # This should be an array with length M_amplitudes.
+               # Example: [1.5e-7, 0.5e-7]
+               # To disable, use [inf, inf, ...] or comment out.
+               # This is only used if run_residual is True.
 
 
 # -------------------------------------------------


### PR DESCRIPTION
I've added the residual trigger into the YAML file, and implemented it into the full detprocess algorithm chain. This allows the user to run a residual trigger: the triggering is done once on the full waveform, then the identified pulses are subtracted, and triggering is done again. If saturation amplitudes are defined, then saturated pulses are ignored on the second pass-through.

Also fixed a few typos/bugs.